### PR TITLE
Updated bower.json: only single copy in main

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
     "name": "angular-nvd3",
     "version": "0.0.9",
     "description": "An AngularJS directive for NVD3.js reusable charting library (based on D3.js)",
-    "main": ["dist/angular-nvd3.js", "dist/angular-nvd3.min.js"],
+    "main": ["dist/angular-nvd3.min.js"],
     "license": "MIT",
     "keywords": [
         "d3",


### PR DESCRIPTION
main falsely included both source + min.   you should have only one  (either one, but the .min makes more sense).
This is important when using automation tools like bowerInstall which automatically inject Bower components into the index.html
