### PR TITLE
Add update method to global api

### DIFF
--- a/src/angular-nvd3.js
+++ b/src/angular-nvd3.js
@@ -26,6 +26,10 @@
                         refresh: function(){
                             scope.api.updateWithOptions(scope.options);
                         },
+                        // Update chart layout (for example if container is resized)
+                        update: function() {
+                            scope.chart.update();
+                        },
                         // Update chart with new options
                         updateWithOptions: function(options){
                             // Clearing


### PR DESCRIPTION
I've been working on a project that requires dynamic layout, currently the chart only updates on window resize and the existing refresh() method in the global API completely resets the chart including the hidden/shown items and stacked/grouped setting.

I've added an update method to the API to expose chart.update() so a simple redraw can be requested through the api, I think this would be a useful addition to the project.
