### PR TITLE
Suggestion: locking d3 to the same version as nvd3

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "angular-nvd3",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "An AngularJS directive for NVD3.js reusable charting library (based on D3.js)",
     "main": ["dist/angular-nvd3.min.js"],
     "license": "MIT",
@@ -27,7 +27,7 @@
         "url": "https://github.com/krispo/angular-nvd3.git"
     },
     "dependencies": {
-        "angular": "~1.2",
+        "angular": "1.26",
         "d3": "3.3.13",
         "nvd3": "~v1.1.15-beta"
     },

--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,7 @@
     },
     "dependencies": {
         "angular": "~1.2",
-        "d3": "~3.4",
+        "d3": "3.3.13",
         "nvd3": "~v1.1.15-beta"
     },
     "ignore": [


### PR DESCRIPTION
so that bower install wont fail on travis

(here is the bower install prompt that led us to the conclusion that we could lock your version of d3 to match nvd3)
![screen shot 2014-10-10 at 12 46 03 am](https://cloud.githubusercontent.com/assets/196199/4588029/691e59ce-5038-11e4-8577-fe1c9e7d4432.png)
