### PR TITLE
Update package.json to play nicer with Browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "type": "git",
         "url": "https://github.com/krispo/angular-nvd3.git"
     },
-    "main": ["dist/angular-nvd3.js", "dist/angular-nvd3.min.js"],
+    "main": "dist/angular-nvd3.js",
     "keywords": [
         "angular",
         "nvd3",


### PR DESCRIPTION
With this change, users can just do `require("angular-nvd3")` instead of `require("angular-nvd3/dist/angular-nvd3")`.

 Great package!
