### PR TITLE
Clear resize handler

### DIFF
--- a/src/angular-nvd3.js
+++ b/src/angular-nvd3.js
@@ -130,7 +130,7 @@
 
                             nv.addGraph(function() {
                                 // Update the chart when window resizes
-                                nv.utils.windowResize(function() { scope.chart.update(); });
+                                scope.chart.resizeHandler = nv.utils.windowResize(function() { scope.chart.update(); });
                                 return scope.chart;
                             }, options.chart['callback']);
                         },
@@ -163,7 +163,13 @@
                             element.find('.subtitle').remove();
                             element.find('.caption').remove();
                             element.empty();
+                            if (scope.chart && scope.chart.resizeHandler) {
+                                scope.chart.resizeHandler.clear();
+                            }
+
                             scope.chart = null;
+                            nv.render.queue = [];
+                            nv.graphs = [];
                         },
 
                         // Get full directive scope


### PR DESCRIPTION
Currently there is no way to remove event handlers created with nv.utils.windowResize. I did a quick and dirty alteration to the code in order to receive the returned object (from nv.utils.windowResize) and call the "clear()" method on that object inside the api.clearElement method (that in turn, removes the handlers.) 
Not sure if this is the best place for it, but if not, I do think the clear() method should be exposed somewhere.