### PR TITLE
add commonjs support following angular 1.X notation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+require('dist/angular-nvd3.js');
+module.exports = 'nvd3';

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "type": "git",
         "url": "https://github.com/krispo/angular-nvd3.git"
     },
-    "main": "dist/angular-nvd3.js",
+    "main": "index.js",
     "keywords": [
         "angular",
         "nvd3",


### PR DESCRIPTION
Updated in the same way that all libraries of angular to support the same kind of notation when declaring a module. Now, instead of:

```javascript
require('angular-nvd3');

module.exports = angular.module('yourModule', [
   require('angular-animate'),
   require('angular-sanitize'),
   'nvd3',
]);
```

this formula can be used:

```javascript
module.exports = angular.module('yourModule', [
   require('angular-animate'),
   require('angular-sanitize'),
   require('angular-nvd3'),
]);
```

See as example: https://github.com/angular/bower-angular-touch/commit/e84314567272ed6cb5287154223ec91d8cd197b5